### PR TITLE
added_prepublish_check

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
     "author": "elastic.io GmbH <info@elastic.io>",
     "engine": "node >=4.1.0",
     "scripts": {
+        "prepublish": "./prepublish.js",
         "pretest": "gulp jscs",
         "test": "gulp test"
     },

--- a/prepublish.js
+++ b/prepublish.js
@@ -1,0 +1,14 @@
+#! /usr/bin/env node
+
+var re = /^\d\d?\.\d\d?\.\d\d?$/;
+var version = require('./package.json').version;
+var versionIsPrerelease = !re.test(version);
+var npmTagIsLatest = process.env.npm_config_tag === 'latest';
+var publishShouldBeRejected = npmTagIsLatest && versionIsPrerelease;
+
+if (publishShouldBeRejected) {
+    console.error('It seems that version "%s" is pre-release. Rejecting publishing it to latest npm tag.', version);
+    console.error(' Did you mean this?');
+    console.error('	npm publish --tag=dev');
+    process.exit(1);
+}


### PR DESCRIPTION
This check will fail when the package is being published with pre-release version (e.g.`1.0.0-dev.0`) into the latest tag in npm (missed option `--tag=dev` for `npm publish` command).
